### PR TITLE
Prevent CloudFront bypass

### DIFF
--- a/terraform/cloudfront-app-service.tf
+++ b/terraform/cloudfront-app-service.tf
@@ -1,3 +1,9 @@
+resource "random_password" "app_service_cloudfront_bypass_protection_secret" {
+  length           = 32
+  special          = true
+  override_special = "123456890"
+}
+
 resource "aws_cloudfront_function" "app_service_viewer_request" {
   name    = "app-service-viewer-request"
   runtime = "cloudfront-js-2.0"
@@ -47,6 +53,11 @@ resource "aws_cloudfront_distribution" "app_service" {
       origin_ssl_protocols     = ["TLSv1.2"]
       origin_keepalive_timeout = 5
       origin_read_timeout      = 30
+    }
+
+    custom_header {
+      name  = "X-CloudFront-Secret"
+      value = random_password.app_service_cloudfront_bypass_protection_secret.result
     }
   }
 

--- a/terraform/ecs-service-alb.tf
+++ b/terraform/ecs-service-alb.tf
@@ -154,6 +154,13 @@ resource "aws_alb_listener_rule" "ecs_service_http_host_header" {
     }
   }
 
+  condition {
+    http_header {
+      http_header_name = "X-CloudFront-Secret"
+      values           = [random_password.app_service_cloudfront_bypass_protection_secret.result]
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       action,


### PR DESCRIPTION
* The load balancer can be reached directly, bypassing CloudFront. To prevent this, we can set a header at the CloudFront layer, with a secret value, and then check the value at the Load Balancer layer
* It's not possible to only allow network traffic from CloudFront to the Load Balancer, so this is the next best option. It would then only be able to be bybpassed if the secret is used.