### PR TITLE
Fix regex for renovate-config-validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: renovate-config-validator
         args: [--strict]
-        files: ^renovate.json$
+        files: ^renovate\.json$
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.23.1


### PR DESCRIPTION
Add a missing `\` to be more explicit about possible filenames to check.