### PR TITLE
Downgrade Python to 3.12 and change awscli install method to fix deployment issues.

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,0 +1,32 @@
+name: Verify Docker Build
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "app-folder/Dockerfile"
+  push:
+    branches:
+      - main
+    paths:
+      - "app-folder/Dockerfile"
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Build Docker image
+        working-directory: app-folder
+        run: |
+          docker build \
+            --tag local-build-test:latest \
+            .

--- a/app-folder/Dockerfile
+++ b/app-folder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.6@sha256:09b29c360b84742bf98eba40b214f7f6b4b53286bb2c8a8b5b1afa188a8d9c0e
+FROM python:3.12.13-trixie@sha256:a9e4190f02729f01e5b3719bd8b3ea0f8d9350dc17d01a1ce1ca6e3fbfcf7a99
 
 # renovate: depName=awscli
 ENV AWS_CLI_VERSION="2.33.27"
@@ -12,7 +12,7 @@ COPY semantic_app.py /code/
 COPY templates /code/templates
 COPY models /models
 
-RUN apt-get update && apt-get install -y --no-install-recommends awscli="${AWS_CLI_VERSION}" && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends awscli="${AWS_CLI_VERSION}" && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 

--- a/app-folder/Dockerfile
+++ b/app-folder/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12.13-trixie@sha256:a9e4190f02729f01e5b3719bd8b3ea0f8d9350dc17d01a1ce1ca6e3fbfcf7a99
 
 # renovate: depName=awscli
-ENV AWS_CLI_VERSION="2.33.27"
+ENV AWS_CLI_VERSION="2.35.14"
 
 RUN useradd -m -u 1000 appuser
 
@@ -12,7 +12,14 @@ COPY semantic_app.py /code/
 COPY templates /code/templates
 COPY models /models
 
-# RUN apt-get update && apt-get install -y --no-install-recommends awscli="${AWS_CLI_VERSION}" && rm -rf /var/lib/apt/lists/*
+ARG AWSCLI_VERSION=2.28.7
+
+RUN curl -fsSL \
+      "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" \
+      -o awscliv2.zip && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 


### PR DESCRIPTION
Added CI docker build for when Dockerfile changes, too

https://national-archives.atlassian.net/browse/FCLC-2067

https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/css-app-build/view?region=eu-west-2

```
#12 [ 8/11] RUN apt-get update && apt-get install -y --no-install-recommends awscli="2.33.27" && rm -rf /var/lib/apt/lists/*
…
#12 2.972 Package awscli is not available, but is referred to by another package.
#12 2.972 This may mean that the package is missing, has been obsoleted, or
#12 2.972 is only available from another source
#12 2.972
#12 2.975 E: Version '2.33.27' for 'awscli' was not found
#12 ERROR: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends awscli=\"${AWS_CLI_VERSION}\" && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```
Additionally, it looks like the wheels for gensim don't support 3.13 or 3.14.
