### PR TITLE
Fix docker streamlit port issue and add healthcheck in CI

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -3,19 +3,14 @@ name: Verify Docker Build
 permissions: {}
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "app-folder/Dockerfile"
   push:
     branches:
       - main
     paths:
-      - "app-folder/Dockerfile"
+      - "app-folder/**"
 
 jobs:
-  docker-build:
+  docker-build-and-health-check:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +25,13 @@ jobs:
           docker build \
             --tag local-build-test:latest \
             .
+
+      - name: Run Docker container for health check
+        run: docker run -d --name app-smoke-test local-build-test:latest
+
+      - name: Wait for container healthy
+        run: timeout 120s bash -c 'until [ "$(docker inspect --format "{{.State.Health.Status}}" app-smoke-test)" = "healthy" ]; do sleep 2; done'
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker logs app-smoke-test

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -3,11 +3,10 @@ name: Verify Docker Build
 permissions: {}
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "app-folder/**"
+  pull_request:
+    branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   docker-build-and-health-check:

--- a/app-folder/Dockerfile
+++ b/app-folder/Dockerfile
@@ -29,8 +29,9 @@ RUN chown -R appuser:appuser /code /models
 
 USER appuser
 
-EXPOSE 80
-HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=6 \
-  CMD curl --fail http://localhost:80/_stcore/health || exit 1
+EXPOSE 8501
 
-CMD ["streamlit", "run", "semantic_app.py", "--server.port=80", "--server.address=0.0.0.0"]
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=6 \
+  CMD curl --fail http://localhost:8501/_stcore/health || exit 1
+
+CMD ["streamlit", "run", "semantic_app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/app-folder/Dockerfile
+++ b/app-folder/Dockerfile
@@ -30,5 +30,7 @@ RUN chown -R appuser:appuser /code /models
 USER appuser
 
 EXPOSE 80
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=6 \
+  CMD curl --fail http://localhost:80/_stcore/health || exit 1
 
 CMD ["streamlit", "run", "semantic_app.py", "--server.port=80", "--server.address=0.0.0.0"]

--- a/terraform/ecs-service-alb.tf
+++ b/terraform/ecs-service-alb.tf
@@ -7,8 +7,8 @@ resource "aws_security_group" "ecs_service_alb" {
 resource "aws_security_group_rule" "ecs_service_alb_container_egress_tcp" {
   description              = "Allow container port tcp egress to containers"
   type                     = "egress"
-  from_port                = 80
-  to_port                  = 80
+  from_port                = 8501
+  to_port                  = 8501
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.app.id
   security_group_id        = aws_security_group.ecs_service_alb.id
@@ -63,7 +63,7 @@ resource "aws_alb" "ecs_service" {
 resource "aws_alb_target_group" "ecs_service_blue" {
   name = "${local.project_name}-ecs-service-b"
 
-  port        = "80"
+  port        = "8501"
   protocol    = "HTTP"
   vpc_id      = aws_vpc.app.id
   target_type = "ip"
@@ -86,7 +86,7 @@ resource "aws_alb_target_group" "ecs_service_blue" {
 resource "aws_alb_target_group" "ecs_service_green" {
   name = "${local.project_name}-ecs-service-g"
 
-  port        = "80"
+  port        = "8501"
   protocol    = "HTTP"
   vpc_id      = aws_vpc.app.id
   target_type = "ip"

--- a/terraform/ecs-service-app.tf
+++ b/terraform/ecs-service-app.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "app" {
   load_balancer {
     target_group_arn = aws_alb_target_group.ecs_service_green.arn
     container_name   = "app"
-    container_port   = 80
+    container_port   = 8501
   }
 
   health_check_grace_period_seconds = 60

--- a/terraform/ecs-service-codedeploy-blue-green.tf
+++ b/terraform/ecs-service-codedeploy-blue-green.tf
@@ -89,7 +89,7 @@ resource "terraform_data" "ecs_service_blue_green_create_codedeploy_deployment" 
       "${path.root}/appspecs/ecs.json.tpl",
       {
         task_definition_arn = aws_ecs_task_definition.app.arn
-        container_port      = 80
+        container_port      = 8501
         container_name      = "app"
       }
     )),
@@ -105,14 +105,14 @@ resource "terraform_data" "ecs_service_blue_green_create_codedeploy_deployment" 
     "${path.root}/appspecs/ecs.json.tpl",
     {
       task_definition_arn = aws_ecs_task_definition.app.arn
-      container_port      = 80
+      container_port      = 8501
       container_name      = "app"
     }), "\"", "\\\"")}" \
       -S "${sha256(templatefile(
     "${path.root}/appspecs/ecs.json.tpl",
     {
       task_definition_arn = aws_ecs_task_definition.app.arn
-      container_port      = 80
+      container_port      = 8501
       container_name      = "app"
 }))}"
     EOF

--- a/terraform/ecs-task-definition-app.tf
+++ b/terraform/ecs-task-definition-app.tf
@@ -12,8 +12,8 @@ resource "aws_ecs_task_definition" "app" {
       image          = aws_ecr_repository.app.repository_url
       entrypoint     = jsonencode(local.app_entrypoint)
       environment    = jsonencode([]),
-      host_port      = 80
-      container_port = 80
+      host_port      = 8501
+      container_port = 8501
       linux_parameters = jsonencode({
         initProcessEnabled = false
       })

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -8,7 +8,7 @@ locals {
   app_github_repo_name                     = var.app_github_repo_name
   app_entrypoint = [
     "/bin/bash", "-c",
-    "aws s3 sync s3://${aws_s3_bucket.models_store.id} /code/models && streamlit run semantic_app.py --server.port=80 --server.address=0.0.0.0"
+    "aws s3 sync s3://${aws_s3_bucket.models_store.id} /code/models && streamlit run semantic_app.py --server.port=8501 --server.address=0.0.0.0"
   ]
   app_cloudfront_tls_certificate_arn  = var.app_cloudfront_tls_certificate_arn
   app_cloudfront_aliases              = var.app_cloudfront_aliases

--- a/terraform/security-group-app-service.tf
+++ b/terraform/security-group-app-service.tf
@@ -6,8 +6,8 @@ resource "aws_security_group" "app" {
 
 resource "aws_security_group_rule" "app_http_ingress" {
   type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
+  from_port                = 8501
+  to_port                  = 8501
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.ecs_service_alb.id
   security_group_id        = aws_security_group.app.id


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-2067

Fix docker streamlit port issue

**Why**
Fix deployment regressions caused by the app running as a non-root user while still binding to privileged port 80, which led to startup failures and blue/green rollback.

**What changed**

- Switched internal app/container port from 80 to 8501 across runtime and ECS/Terraform wiring to match non-root execution (https://docs.streamlit.io/deploy/tutorials/docker).
- Added Docker image health check in using Streamlit health endpoint.
- Added/updated GitHub PR container smoke test to: build the image, start the container, wait for Docker health status healthy, print logs on failure.
- Expanded workflow path trigger from only Dockerfile to any PR event so app/runtime or infra changes also run the smoke test.

**Outcome**
PRs now fail early on container startup/health regressions, reducing risk of broken deploys reaching CodePipeline.