### PR TITLE
Fix ecs service resource version

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,35 @@
+# Terraform Folder Guide
+
+This folder mixes Terraform-managed infrastructure with templates used at CI/CD runtime.
+
+## Template ownership and usage
+
+### Terraform-consumed templates
+
+These files are read by Terraform during `terraform plan/apply` via `templatefile(...)`:
+
+- `policies/`
+- `buildspecs/`
+- `cloudfront-functions/`
+
+### Runtime-rendered templates (not directly applied by Terraform)
+
+These files are rendered during CodeBuild/CodePipeline execution and passed to AWS APIs:
+
+- `appspecs/`
+- `container-definitions/`
+
+In particular:
+
+- `appspecs/ecs.json.tpl` is rendered to `appspec.json` by CodeBuild and used by CodeDeploy.
+- `container-definitions/app.json.tpl` is rendered by CodeBuild and used to register a new ECS task definition.
+
+## Why this matters
+
+- Editing Terraform-consumed templates may require `terraform apply` to update infrastructure configuration.
+- Editing runtime-rendered templates usually requires commit/push and a new pipeline run, but not a Terraform apply.
+
+## Current wiring
+
+- `codebuild-app-build-pipeline.tf` injects `buildspecs/app.json.tpl` into the CodeBuild project.
+- `buildspecs/app.json.tpl` renders `container-definitions/app.json.tpl` and `appspecs/ecs.json.tpl` using `envsubst`.

--- a/terraform/appspecs/ecs.json.tpl
+++ b/terraform/appspecs/ecs.json.tpl
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 0.0,
   "Resources": [
     {
       "TargetService": {


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-2067

- Fix CodeDeploy by setting ECS service version to only accepted value, 0.0, in ecs.json.tpl
https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-example.html#appspec-file-example-ecs

- Add Terraform Folder Guide documentation for template usage and management